### PR TITLE
add DoctorScopeFunc detection + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ refactoring, you may do the following:
 Add the following to your `.vimrc`:
 
 ```viml
+function! s:find_git_root()
+  return system('git rev-parse --show-toplevel 2> /dev/null')[:-2]
+endfunction
+
 function! DoctorScopeFunc()
   let l:gp = $GOPATH
   if l:gp == ""

--- a/README.md
+++ b/README.md
@@ -51,4 +51,26 @@ Highlighting block to extract:
 
 `:Refactor extract newfunc`
 
+## Setting scope to git root
+
+The default scope will be `$PWD`, if none is set explicitly with
+`g:doctor_scope`. If you would prefer to use the git root scope on every
+refactoring, you may do the following:
+
+Add the following to your `.vimrc`:
+
+```viml
+function! DoctorScopeFunc()
+  let l:gp = $GOPATH
+  if l:gp == ""
+    return ""
+  endif
+
+  let l:gp = l:gp."/src/"
+  let l:gr = s:find_git_root()
+
+  return substitute(l:gr, l:gp, "", "")
+endfunction
+```
+
 <!-- TODO mo betta docs -->

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -329,9 +329,14 @@ func! s:RunDoctor(selected, refac, ...) range abort
     endif
   endfor
 
-  if !exists("g:doctor_scope")
-    let s:scope = ""
-  else
+  let s:scope = ""
+
+  " set scope from func, if exists. allow hard g:doctor_scope to override
+  if exists("*DoctorScopeFunc")
+    let s:scope = " -scope=".shellescape(DoctorScopeFunc())
+  endif
+
+  if exists("g:doctor_scope")
     let s:scope = " -scope=".shellescape(g:doctor_scope)
   endif
 


### PR DESCRIPTION
this outlines in the README how to set up an example git root implementation
for this. it's a tad annoying that scope does not do any correcting for
absolute file paths that are within the $GOPATH, but it's not too hard to add
for now to get around this, briefly looked at adding that into core godoctor,
but has obvious ux implications so just did it here.

initially, i had just defined a command like `DoctorScopeFunc` that
sets `g:doctor_scope` instead of returning the desired output, and this works
of course, but it's nice to just define this once in my vim file and not have
to think about it and let the doctor order it up itself instead of having to
remember to call it before i do a refactoring. so, this patch isn't required
to get the behavior i want but attempts to improve it by adding it into the doctor plugin.

~related https://github.com/godoctor/godoctor/issues/41 (doesn't entirely 'fix' but as far as i'm concerned, i got what i wanted :)